### PR TITLE
Multiscale peak counts

### DIFF
--- a/DifferentiableHOS/statistics/peak_counts_tf.py
+++ b/DifferentiableHOS/statistics/peak_counts_tf.py
@@ -8,13 +8,24 @@ From lenspack implementation
 import tensorflow as tf
 import numpy as np
 import tensorflow_probability as tfp
+from DifferentiableHOS.transforms import starlet2d
 
 
 def _kernel(bw, X, x):
     """Gaussian kernel for KDE"""
-    return (1.0 / np.sqrt(2 * np.pi) / bw) * tf.math.exp(
-        -((X - x) ** 2) / (bw ** 2 * 2.0)
-    )
+    return (1.0 / np.sqrt(2 * np.pi) / bw) * tf.math.exp(-((X - x)**2) /
+                                                         (bw**2 * 2.0))
+
+
+def _get_wavelet_normalization(image, nscales):
+    """ Computes normalizing constant for starlet, for given image.
+  """
+    _, nx, ny = image.get_shape()
+    knorm = tf.ones((1, 1, 1, 1), dtype=tf.float32)
+    knorm = tf.image.resize_with_crop_or_pad(knorm, nx, ny)
+    wt = starlet2d(knorm[..., 0], nscales=nscales)
+    return [tf.math.sqrt(tf.reduce_sum(c**2)) for c in wt]
+
 
 @tf.function
 def find_peaks2d_tf(image, mask=None, ordered=True, threshold=None):
@@ -68,11 +79,75 @@ def find_peaks2d_tf(image, mask=None, ordered=True, threshold=None):
     return XY[:, 0], XY[:, 1], heights
 
 
+@tf.function
+def peaks_histogram_tf_mulscale(image,
+                                nscales=3,
+                                value_range=[-1., 1.],
+                                nbins=16,
+                                mask=None,
+                                name='peakscount',
+                                bw_factor=2.):
+    """Compute a histogram of peaks in a 2d Starlet transform of the input image.
+
+    Parameters
+    ----------
+    image : tensor (2D)
+        Two-dimensional input tensor
+    nscales: int
+        Number of wavelet scales to include
+        in the decomposition.
+    value_range: Shape [2] Tensor of same dtype as image
+        Range of values in the Histogram.
+    nbins : int 
+        Specification the number of bins to use for the
+        histogram. 
+    mask : tensor (same shape as `image`), optional
+        Tensor identifying which pixels of `image` to consider/exclude
+        in finding peaks. Can either either be numeric (0 or 1) or boolean 
+        (false or true)
+    bw_factor: float
+        Factor by which to divide the bin width to define the bandwidth of the
+        smoothing kernel.
+    Returns
+    -------
+    results, bins : list of 1D tensors
+        Histogram and bin boundary values. 
+     """
+    with tf.name_scope(name):
+        image = tf.cast(image, dtype=tf.float32)
+
+        # Compute the wavelet normalization factor
+        norm_factors = _get_wavelet_normalization(image, nscales)
+
+        # Compute wavelet transform
+        wt = starlet2d(image, nscales)
+        results = []
+        # Loop over all wavelet scales
+        for coeffs, factor in zip(wt, norm_factors):
+            # Normalizing coefficients to preserve standard deviations
+            # across scales
+            coeffs = coeffs / factor
+
+            # Histogram the coefficient values
+            bins = tf.linspace(value_range[0], value_range[1], nbins)
+            image = tf.reshape(coeffs, [coeffs.shape[1], coeffs.shape[2]])
+            x, y, heights = find_peaks2d_tf(image, threshold=None, mask=mask)
+
+            # To avoid issues, we clip the image to within the peaks
+            heights = tf.clip_by_value(heights, bins[0], bins[-1])
+            w = tf.reshape(tf.ones_like(heights), [-1])
+            k = _kernel(
+                tf.reduce_mean((bins[1:] - bins[:-1])) / bw_factor,
+                tf.reshape(heights, [-1, 1]), bins)
+            k = k / tf.reduce_sum(k, axis=1, keepdims=True)
+            counts = tf.tensordot(k, w, axes=[[0], [0]])
+            results.append(counts)
+    return results, bins
+
 
 @tf.function
 def peaks_histogram_tf(image, bins=None, mask=None, bw_factor=2.):
     """Compute a histogram of peaks in a 2d image.
-
     Parameters
     ----------
     image : tensor (2D)
@@ -94,10 +169,13 @@ def peaks_histogram_tf(image, bins=None, mask=None, bw_factor=2.):
         Histogram and bin boundary values. If the returned `counts` has 
         N values, `bin_edges` will have N + 1 values.
      """
+    image = tf.cast(image, dtype=tf.float32)
     if bins is None:
-        bins = tf.linspace(tf.math.reduce_min(image), tf.math.reduce_max(image), 10)
+        bins = tf.linspace(tf.math.reduce_min(image),
+                           tf.math.reduce_max(image), 10)
     elif isinstance(bins, int):
-        bins = tf.linspace(tf.math.reduce_min(image), tf.math.reduce_max(image), bins)
+        bins = tf.linspace(tf.math.reduce_min(image),
+                           tf.math.reduce_max(image), bins)
     else:
         bins = bins
 
@@ -107,11 +185,14 @@ def peaks_histogram_tf(image, bins=None, mask=None, bw_factor=2.):
     heights = tf.clip_by_value(heights, bins[0], bins[-1])
 
     w = tf.reshape(tf.ones_like(heights), [-1])
-    k = _kernel(tf.reduce_mean((bins[1:] -  bins[:-1]))/bw_factor, tf.reshape(heights,[-1,1]), bins)
-    k =  k / tf.reduce_sum(k, axis=1, keepdims=True) 
-    counts = tf.tensordot(k, w, axes = [[0], [0]]) 
+    k = _kernel(
+        tf.reduce_mean((bins[1:] - bins[:-1])) / bw_factor,
+        tf.reshape(heights, [-1, 1]), bins)
+    k = k / tf.reduce_sum(k, axis=1, keepdims=True)
+    counts = tf.tensordot(k, w, axes=[[0], [0]])
 
     return counts, bins
+
 
 @tf.function
 def non_diffable_peaks_histogram_tf(image, bins=None, mask=None):
@@ -150,6 +231,5 @@ def non_diffable_peaks_histogram_tf(image, bins=None, mask=None):
     # To avoid issues, we clip the image to within the peaks
     heights = tf.clip_by_value(heights, bins[0], bins[-1])
 
-    counts = tfp.stats.histogram(heights,bins)
-    return counts,bins
-
+    counts = tfp.stats.histogram(heights, bins)
+    return counts, bins

--- a/scripts/compute_jacobian.py
+++ b/scripts/compute_jacobian.py
@@ -203,7 +203,7 @@ def compute_jacobian(Omega_c, sigma8, Omega_b, n_s, h, w0, Aia, pgdparams):
                         experimental_use_pfor=False,
                         parallel_iterations=1)
 
-    return kmap_IA, kmap, lensplanes, r_center, a_center, jac, ell, power_spectrum
+    return  kmap, lensplanes, r_center, a_center, jac, ell, power_spectrum
 
 
 def main(_):
@@ -214,7 +214,7 @@ def main(_):
         pgd_data = pickle.load(f)
         pgdparams = pgd_data['params']
 
-    kmap_IA, kmap, lensplanes, r_center, a_center, jac_ps, ell, ps = compute_jacobian(
+    kmap, lensplanes, r_center, a_center, jac_ps, ell, ps = compute_jacobian(
         tf.convert_to_tensor(FLAGS.Omega_c, dtype=tf.float32),
         tf.convert_to_tensor(FLAGS.sigma8, dtype=tf.float32),
         tf.convert_to_tensor(FLAGS.Omega_b, dtype=tf.float32),
@@ -228,7 +228,6 @@ def main(_):
             'a': a_center,
             'lensplanes': lensplanes,
             'r': r_center,
-            'kmap_IA': kmap_IA.numpy(),
             'kmap': kmap.numpy(),
             'ell': ell.numpy(),
             'ps': ps.numpy(),

--- a/scripts/compute_jacobian.py
+++ b/scripts/compute_jacobian.py
@@ -16,7 +16,7 @@ import time
 from flowpm import tfpm
 import tensorflow_probability as tfp
 from scipy.stats import norm
-from flowpm.NLA_IA import interpolation,k_IA
+from flowpm.NLA_IA import k_IA
 from flowpm.fourier_smoothing import fourier_smoothing
 from flowpm.tfbackground import rad_comoving_distance
 
@@ -51,7 +51,7 @@ FLAGS = flags.FLAGS
 
 
 @tf.function
-def compute_kappa(Omega_c, sigma8, Omega_b, n_s, h, w0, pgdparams):
+def compute_kappa(Omega_c, sigma8, Omega_b, n_s, h, w0, Aia, pgdparams):
     """ Computes a convergence map using ray-tracing through an N-body for a given
     set of cosmological parameters
     """
@@ -122,17 +122,33 @@ def compute_kappa(Omega_c, sigma8, Omega_b, n_s, h, w0, pgdparams):
     coords = np.stack([xgrid, ygrid], axis=0)
     c = coords.reshape([2, -1]).T / 180. * np.pi  # convert to rad from deg
     # Create array of source redshifts
-    z_source = tf.constant([[0.9720714]])
+    lens_source = states[::-1][11][1]
+    lens_source_a = states[::-1][11][0]
+    z_source = 1 / lens_source_a - 1
     m = flowpm.raytracing.convergenceBorn(cosmology,
                                           lensplanes,
                                           dx=FLAGS.box_size / 2048,
                                           dz=FLAGS.box_size,
                                           coords=c,
-                                          z_source=z_source)
+                                          z_source=z_source,
+                                          field_npix=FLAGS.field_npix)
 
-    m = tf.reshape(m, [FLAGS.batch_size, FLAGS.field_npix, FLAGS.field_npix])
-
-    return m, states, lensplanes, r_center, a_center
+    r_source = rad_comoving_distance(cosmology, lens_source_a)
+    plane_source = flowpm.raytracing.density_plane(
+        lens_source,
+        [FLAGS.nc, FLAGS.nc, FLAGS.nc],
+        FLAGS.nc // 2,
+        width=FLAGS.nc,
+        plane_resolution=2048,
+    )
+    im_IA = flowpm.raytracing.interpolation(plane_source,
+                                            dx=FLAGS.box_size / 2048,
+                                            r_center=r_source,
+                                            field_npix=FLAGS.field_npix,
+                                            coords=c)
+    k_ia = k_IA(cosmology, lens_source_a, im_IA, Aia)
+    kmap_IA = m - k_ia
+    return kmap_IA, states, lensplanes, r_center, a_center
 
 
 def desc_y1_analysis(kmap):
@@ -153,48 +169,6 @@ def desc_y1_analysis(kmap):
     return kmap
 
 
-def add_IA(states, Omega_c, sigma8, Omega_b, n_s, h, w0, Aia):
-    cosmology = flowpm.cosmology.Planck15(Omega_c=Omega_c,
-                                          sigma8=sigma8,
-                                          Omega_b=Omega_b,
-                                          n_s=n_s,
-                                          h=h,
-                                          w0=w0)
-    
-    lens_source=states[::-1][11][1]
-    lens_source_a=states[::-1][11][0]  
-    z_source=1/lens_source_a-1
-    r_source=rad_comoving_distance(cosmology,lens_source_a)
-    plane_source = flowpm.raytracing.density_plane(
-        lens_source,
-        [FLAGS.nc, FLAGS.nc, FLAGS.nc],
-        FLAGS.nc // 2,
-        width=FLAGS.nc,
-        plane_resolution=2048,
-    )
-    pix_scale_source =FLAGS.box_size/2048  #Mpc
-    sigma_pix_source = FLAGS.sigma_k / pix_scale_source
-    xgrid, ygrid = np.meshgrid(
-        np.linspace(0,
-                    FLAGS.field_size,
-                    FLAGS.field_npix,
-                    endpoint=False),  # range of X coordinates
-        np.linspace(0,
-                    FLAGS.field_size,
-                    FLAGS.field_npix,
-                    endpoint=False))  # range of Y coordinates
-
-    coords = np.stack([xgrid, ygrid], axis=0) * u.deg
-    c = coords.reshape([2, -1]).T.to(u.rad)
-    im = interpolation(plane_source,
-                       dx=FLAGS.box_size /2048,
-                       r_source=r_source,
-                       field_npix=FLAGS.field_npix,
-                       coords=c)
-    k_ia=k_IA(cosmology,lens_source_a,im,Aia)
-    return k_ia
-
-
 def rebin(a, shape):
     sh = shape, a.shape[0] // shape
     return tf.math.reduce_mean(tf.reshape(a, sh), axis=-1)
@@ -207,18 +181,15 @@ def compute_jacobian(Omega_c, sigma8, Omega_b, n_s, h, w0, Aia, pgdparams):
     params = tf.stack([Omega_c, sigma8, Omega_b, n_s, h, w0, Aia])
     with tf.GradientTape() as tape:
         tape.watch(params)
-        m, states, lensplanes, r_center, a_center = compute_kappa(
+        kmap_IA, states, lensplanes, r_center, a_center = compute_kappa(
             params[0], params[1], params[2], params[3], params[4], params[5],
-            pgdparams)
+            params[6], pgdparams)
 
         # Adds realism to convergence map
-        k_ia = add_IA(states, params[0], params[1], params[2],
-                              params[3], params[4], params[5], params[6])
-        m = m[0] - k_ia
-        kmap_IA = desc_y1_analysis(m)
+        kmap = desc_y1_analysis(kmap_IA)
         # Compute power spectrum
         ell, power_spectrum = DHOS.statistics.power_spectrum(
-            kmap_IA[0], FLAGS.field_size, FLAGS.field_npix)
+            kmap[0], FLAGS.field_size, FLAGS.field_npix)
 
         # Keep only ell between 300 and 3000
         ell = ell[2:46]
@@ -232,7 +203,7 @@ def compute_jacobian(Omega_c, sigma8, Omega_b, n_s, h, w0, Aia, pgdparams):
                         experimental_use_pfor=False,
                         parallel_iterations=1)
 
-    return m, kmap_IA, lensplanes, r_center, a_center, jac, ell, power_spectrum
+    return kmap_IA, kmap, lensplanes, r_center, a_center, jac, ell, power_spectrum
 
 
 def main(_):
@@ -243,7 +214,7 @@ def main(_):
         pgd_data = pickle.load(f)
         pgdparams = pgd_data['params']
 
-    m, kmap_IA, lensplanes, r_center, a_center, jac_ps, ell, ps = compute_jacobian(
+    kmap_IA, kmap, lensplanes, r_center, a_center, jac_ps, ell, ps = compute_jacobian(
         tf.convert_to_tensor(FLAGS.Omega_c, dtype=tf.float32),
         tf.convert_to_tensor(FLAGS.sigma8, dtype=tf.float32),
         tf.convert_to_tensor(FLAGS.Omega_b, dtype=tf.float32),
@@ -257,8 +228,8 @@ def main(_):
             'a': a_center,
             'lensplanes': lensplanes,
             'r': r_center,
-            'map': m.numpy(),
             'kmap_IA': kmap_IA.numpy(),
+            'kmap': kmap.numpy(),
             'ell': ell.numpy(),
             'ps': ps.numpy(),
             'jac_ps': jac_ps.numpy()


### PR DESCRIPTION
This pull request adds to the code [peak_counts_tf](https://github.com/LSSTDESC/DifferentiableHOS/blob/53a2ed18a0debf50f00660f8f03f8b441f7cce1e/DifferentiableHOS/statistics/peak_counts_tf.py) an addition version of the peak counts function meant to count weak lensing peaks on the Starlet filtered maps. 

It also contains a new version of the python [script](https://github.com/LSSTDESC/DifferentiableHOS/blob/53a2ed18a0debf50f00660f8f03f8b441f7cce1e/scripts/compute_jacobian.py) meant to compute the Jacobian of the angular power spectrum  from simulations containing the IA-NLA.

